### PR TITLE
 - Fix bug where output filenames have two extensions (E.G - styles.css_1.css)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ wget http://yui.yahooapis.com/pure/0.5.0/pure-min.css
 
 ## Version history
 
+* v0.4.1 (2015-06-21) Fix bug where output filename extensions were incorrect
 * v0.4.0 (2015-03-11) Update Sakugawa to `v0.4.0` which preserves existing `@charset` rules to all resulting files
 * v0.3.0 (2015-02-23) Update Sakugawa to `v0.3.0` which adds the `minSheets` option
 * v0.2.0 (2014-11-19) First release, directly paired with Speed improvement release of Sakugawa

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ module.exports = function gulpSakugawa(opts) {
       var _self = this;
       var decoder = new StringDecoder(enc);
       var css = decoder.write(chunk.contents);
+      var extension = chunk.relative.split('.').pop().toLowerCase();
+      var filename = (extension === 'css' ? chunk.relative.substring(0, chunk.relative.length - 4) : chunk.relative);
 
       var pages = sakugawa(css, options);
 
@@ -40,7 +42,7 @@ module.exports = function gulpSakugawa(opts) {
         var cssFile = new File({
           cwd: chunk.cwd,
           base: chunk.base,
-          path: path.join(chunk.base, '', chunk.relative) + suffix + (index + 1) + '.css',
+          path: path.join(chunk.base, '', filename) + suffix + (index + 1) + '.css',
           contents: new Buffer(page)
         });
         _self.push(cssFile);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sakugawa",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Run Sakugawa via gulp for CSS splitting, filtering and organising",
   "homepage": "https://github.com/paazmaya/gulp-sakugawa",
   "author": {


### PR DESCRIPTION
Hi,

I have been trying to use your plugin in my gulpfile recently and I noticed that the names of the split files created are a bit odd. If i input 'styles.css' I will end up with 'styles.css_1.css' and 'styles.css_2.css'. 

I like to offer solutions to problems I find so I have forked and created a fix. Could you please have a look and see if you would like to merge? It may be that this isn't the most elegant way to do things (Im good at JS, but new to node.js) so feel free to reject this. It would be good to have this fixed though! 

In case its of use, I'm using Mac OSX 10.10.


Kind regards,
Alex