### PR TITLE
Only create split file if needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,13 +39,16 @@ module.exports = function gulpSakugawa(opts) {
 
       pages.forEach(function (page, index) {
         // add new source map file to stream
-        var cssFile = new File({
-          cwd: chunk.cwd,
-          base: chunk.base,
-          path: path.join(chunk.base, '', filename) + suffix + (index + 1) + '.css',
-          contents: new Buffer(page)
-        });
-        _self.push(cssFile);
+        if (pages.length > 1) {
+          // only create a new file if splitting is required
+          var cssFile = new File({
+            cwd: chunk.cwd,
+            base: chunk.base,
+            path: path.join(chunk.base, '', filename) + suffix + (index + 1) + '.css',
+            contents: new Buffer(page)
+          });
+          _self.push(cssFile);
+        }
       });
     }
     return cb();

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ module.exports = function gulpSakugawa(opts) {
 
       var pages = sakugawa(css, options);
 
-      pages.forEach(function (page, index) {
-        // add new source map file to stream
-        if (pages.length > 1) {
-          // only create a new file if splitting is required
+      if (pages.length > 1) {
+        // only create a new file if splitting is required
+        pages.forEach(function(page, index) {
+          // add new source map file to stream
           var cssFile = new File({
             cwd: chunk.cwd,
             base: chunk.base,
@@ -48,8 +48,8 @@ module.exports = function gulpSakugawa(opts) {
             contents: new Buffer(page)
           });
           _self.push(cssFile);
-        }
-      });
+        });
+      }
     }
     return cb();
   });


### PR DESCRIPTION
This might not be right for Sakugawa but my use case was to split out stylesheets after n selectors. I found that it was splitting stylesheets under the selector limit so I would end up with unneeded files. 

This PR means that it only outputs files if splitting has occurred. Apologies if I've missed a setting that already does this or not created this PR correctly!